### PR TITLE
Fix footer & points overview graph & pre

### DIFF
--- a/darkMode.css
+++ b/darkMode.css
@@ -18,6 +18,10 @@
     color: #ccc !important;
 }
 
+.card-body pre{
+    background-color: #2d2d2d;
+}
+
 .page-wrapper {
     background-color: #2d2d2d !important;
     color: #ccc !important;
@@ -464,7 +468,8 @@ text {
 }
 
 path {
-    stroke: #ccc !important;
+    stroke: #5e5e5e !important;
+    stroke-linecap: round;
 }
 
 polygon {

--- a/darkMode.css
+++ b/darkMode.css
@@ -43,7 +43,10 @@
 }
 
 .footer.fixed {
-    background-color: #1c1c1c;
+    background-color: #1c1c1c !important; 
+}
+.footer-text {
+    color: #ccc !important; 
 }
 
 .dropdown-menu {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "ArtemisDarkMode",
-    "version": "1.1",
+    "version": "1.1.1",
     "description": "Adds a dark mode for all webpages matching artemis.ase.",
     "icons": {
         "235": "icons/icon-235.png"


### PR DESCRIPTION
As pictures speak louder than words:
Fixed the footer in desktop viewsize:
from:
![footer-unfixed](https://user-images.githubusercontent.com/92096842/147005983-8d1bffd7-5bb2-40b8-9428-9def049c4642.png)
to:
![footer-fixed](https://user-images.githubusercontent.com/92096842/147005981-27e40de1-ff10-4178-b4cf-e9d061501f07.png)

Fixed the overview graph, by changing the stroke / outlining to gray instead of white:
from:
![point-unfixed](https://user-images.githubusercontent.com/92096842/147005988-fa0bd722-9d7d-45dc-baec-2d9c2ccf0b1b.png)
to:
![point-fixed](https://user-images.githubusercontent.com/92096842/147005986-3d2b0912-157a-4ca6-9d2e-934bc11e484f.png)

Fixed the "pre" element in the maze exercise:
from:
![pre-unfixed](https://user-images.githubusercontent.com/92096842/147005991-c55319d3-c2f9-4720-8d2f-7be00651115c.png)
to:
![pre-fixed](https://user-images.githubusercontent.com/92096842/147005990-2e91f56b-b04e-4bcf-a7f7-95ec7f28697b.png)
