### PR TITLE
Fix: instruction images and modal-content  

### DIFF
--- a/darkMode.css
+++ b/darkMode.css
@@ -791,3 +791,13 @@ div.stepwizard-step > div.stepwizard-step--failed:hover {
 jhi-programming-exercise-instructions img {
 background-color: #4b4b4b;
 }
+
+.modal-content {
+    color: #ccc;
+}
+.modal-content button{
+    background-color: #4b4b4b;
+}
+.modal-content button:hover{
+    background-color: #4c4c4c;
+}

--- a/darkMode.css
+++ b/darkMode.css
@@ -787,3 +787,7 @@ div.stepwizard-step > div.stepwizard-step--success:hover {
 div.stepwizard-step > div.stepwizard-step--failed:hover {
     background-color: #da0f0f !important;
 }
+
+jhi-programming-exercise-instructions img {
+background-color: #4b4b4b;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "ArtemisDarkMode",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Adds a dark mode for all webpages matching artemis.ase.",
     "icons": {
         "235": "icons/icon-235.png"


### PR DESCRIPTION
As pictures speak louder than words:
instruction images
from:
![image](https://user-images.githubusercontent.com/92096842/147608731-6fec0e21-8726-4a6b-9748-167efc4b9b9a.png)
to:
![image](https://user-images.githubusercontent.com/92096842/147608814-b655b743-d6a5-4085-b57d-68b95e45ec2a.png)

modal content:
from:
![image](https://user-images.githubusercontent.com/92096842/147608872-c86e2750-2a3f-49de-82f0-359e9bc89f7a.png)
to:
![image](https://user-images.githubusercontent.com/92096842/147608917-4cc72787-331d-4916-9224-130360afdcde.png)


Just as a friendly reminder: If you have time, please update the firefox and chrome web store versions aswell. 